### PR TITLE
Fix a flaky test by cleaning a polluted state.

### DIFF
--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -526,6 +526,7 @@ class TestMagicMethods(unittest.TestCase):
 		self.assertEqual(who.born, [b1, b2])
 
 	def test_not_multiple_instance(self):
+		model.factory.auto_id_type = 'int-per-segment'
 		who = model.Person()
 		n = model.Name(content="Test")
 		who.identified_by = n

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -280,6 +280,7 @@ class TestAutoIdentifiers(unittest.TestCase):
 		model.factory.auto_id_type = "broken"
 		self.assertRaises(model.ConfigurationError, model.factory.generate_id,
 			"irrelevant")
+		model.factory.auto_id_type = 'int-per-segment'
 
 	def test_int(self):
 		model.factory.auto_assign_id = True
@@ -526,7 +527,6 @@ class TestMagicMethods(unittest.TestCase):
 		self.assertEqual(who.born, [b1, b2])
 
 	def test_not_multiple_instance(self):
-		model.factory.auto_id_type = 'int-per-segment'
 		who = model.Person()
 		n = model.Name(content="Test")
 		who.identified_by = n


### PR DESCRIPTION
# What is the purpose of the change
This PR is to fix a flaky test `tests/test_model.py::TestMagicMethods::test_not_multiple_instance` after running `tests/test_model.py::TestAutoIdentifiers::test_bad_autoid`, but passes when it is run in isolation.

# Reproduce the test failure
Run the following command:
```
python -m pytest tests/test_model.py::TestAutoIdentifiers::test_bad_autoid tests/test_model.py::TestMagicMethods::test_not_multiple_instance
```

# Expexted result
 Test `tests/test_model.py::TestMagicMethods::test_not_multiple_instance` should pass after running `tests/test_model.py::TestAutoIdentifiers::test_bad_autoid`.

# Actual result
```
        else:
>               raise ConfigurationError("Unknown auto-id type")
E     cromulent.model.ConfigurationError: Unknown auto-id type

cromulent/model.py:281: ConfigurationError
```
# Why it fails
`model.factory.auto_id_type` is polluted after `tests/test_model.py::TestAutoIdentifiers::test_bad_autoid`

# Fix
Reset `model.factory.auto_id_type` to `int-per-segment` at the end of `tests/test_model.py::TestAutoIdentifiers::test_bad_autoid to avoid flaky tests.