### PR TITLE
Fix a flaky test by resetting a polluted state.

### DIFF
--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -74,6 +74,7 @@ class TestFactorySerialization(unittest.TestCase):
 			js=badjs)
 
 	def test_toJSON(self):
+		model.factory.context_uri = 'https://linked.art/ns/v1/linked-art.json'
 		# model.factory.context_uri = 'http://lod.getty.edu/context.json'
 		expect = OrderedDict([
 			('@context', model.factory.context_uri),


### PR DESCRIPTION
## What is the purpose of the change
This PR is to fix a flaky test `tests/test_model.py::TestFactorySerialization::test_toJSON` , which can fail after running `tests/test_multiple_instantiation.py::TestMIClasses::test_destruction`,  but passes when it is run in isolation.

## Reproduce the test failure
Run the following command:
```
python -m pytest tests/test_multiple_instantiation.py::TestMIClasses::test_destruction tests/test_model.py::TestFactorySerializat
ion::test_toJSON
```
## Expected result
Test `tests/test_model.py::TestFactorySerialization::test_toJSON` should pass when it is run after test `tests/test_multiple_instantiation.py::TestMIClasses::test_destruction`.

## Actual result
```
>       self.assertEqual(expect, outj)
E    AssertionError: OrderedDict([('@context', ''), ('id', 'http://lod.exampl[98 chars]t')]) != OrderedDict([('id', 'http://lod.example.org/museum/Infor[80 chars]t')])

tests/test_model.py:83: AssertionError
```
## Why the test fails
`context_uri` is set as none at the end of `tests/test_multiple_instantiation.py::TestMIClasses::test_destruction`, which can lead `tests/test_model.py::TestFactorySerialization::test_toJSON` to fail.

## Fix
Reset `model.factory.context_uri` at the start of `tests/test_model.py::TestFactorySerialization::test_toJSON`.